### PR TITLE
Add --xfwd argument to add x-forward headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Usage: https-proxy <options>
 Options:
   -t, --target  target address, like http://localhost:80  [required]
   -p, --port    port to use for https                     [required]
-  --keys        path for storing .key.pem and .cert.pem   [string]  [default: undefined]
+  --keys        path for storing .key.pem and .cert.pem   [string]  [default: "."]
+  --insecure    flag to accept insecure connections
+  --xfwd        adds x-forward headers
+
 
 ```

--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,8 @@ const argv = require('optimist')
   .default('keys', '.')
   .alias('k', 'insecure')
   .describe('insecure', 'flag to accept insecure connections')
+  .alias('x', 'xfwd')
+  .describe('xfwd', 'adds x-forward headers')
   .argv
 
 function getKeys (callback) {
@@ -65,7 +67,8 @@ getKeys((err, keys) => {
       key: keys.serviceKey,
       cert: keys.certificate
     },
-    secure: !argv.insecure
+    secure: !argv.insecure,
+    xfwd: argv.xfwd
   }).listen(argv.port, _ => {
     console.log(`HTTPS proxy started on https://localhost:${argv.port}`)
   })


### PR DESCRIPTION
Sometimes it is needed that x-forward headers are set, such that the target can trust the proxy and use that information.

e.g.: when testing secure cookies

Closes #16 